### PR TITLE
Fix: Popup is not visible in full screen 

### DIFF
--- a/plus.js
+++ b/plus.js
@@ -77,7 +77,7 @@ document.arrive(".shaka-volume-bar-container", function() {
 
         // action info popup
         action_popup = "<div id='mpp-action-popup'></div>";
-        document.getElementsByClassName("ion-page")[0].insertAdjacentHTML("afterbegin", action_popup);
+        document.getElementsByClassName("shaka-video-container")[0].insertAdjacentHTML("afterbegin", action_popup);
         popup = document.getElementById("mpp-action-popup");
 
         // download button


### PR DESCRIPTION
Related to issue #27 

Solution: Inject the `#mpp-action-popup` popup div into `.shaka-video-container` instead of the original `.ion-page` so that the popup is visible in full screen.

Before:
![image](https://user-images.githubusercontent.com/29315719/83594946-b2c25d00-a5b4-11ea-9486-f88866f49052.png)

After:
![image](https://user-images.githubusercontent.com/29315719/83594955-b8b83e00-a5b4-11ea-82ba-5b3a16b0eada.png)

p.s. First time playing with Chrome Extension / Injection so I don't really know if I am doing this right 😋