### PR TITLE
Added in the Default Resolution Setting

### DIFF
--- a/popup/index.html
+++ b/popup/index.html
@@ -44,7 +44,21 @@
             <li>
                 <a href="#">Settings</a>
                 <ul>
-                    <li><a href="#">Submenu entry 1</a></li>
+                    <li><a href="#">Default Playback Resolution</a>
+                        <ul id="defaultPlaybackResolution" type="radioHolder">
+                            <label for="720p" class="defaultRadioLabel">720p</label>
+                            <input type="radio" name="defaultPlaybackResolution" class="radioHolderEntry" value="720p"/>
+                            <br>
+                            <label for="540p" class="defaultRadioLabel">540p</label>
+                            <input type="radio" name="defaultPlaybackResolution" class="radioHolderEntry" value="540p"/>
+                            <br>
+                            <label for="360p" class="defaultRadioLabel">360p</label>
+                            <input type="radio" name="defaultPlaybackResolution" class="radioHolderEntry" value="360p"/>
+                            <br>
+                            <label for="Auto" class="defaultRadioLabel">Auto</label>
+                            <input type="radio" name="defaultPlaybackResolution" class="radioHolderEntry" value="Auto"/>
+                        </ul>
+                    </li>
                     <li><a href="#">Submenu entry 2</a></li>
                     <li><a href="#">Submenu entry 3</a></li>
                 </ul>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -64,7 +64,21 @@ loadGlobalSettings(function(returned){
                     console.log(settings)
                     saveGlobalSettings(settings);
                 });
-            }
+            } else if (control.type == "radioHolder"){
+                defaultValue = settings[setting];
+                radios = document.getElementById(setting).querySelectorAll(".radioHolderEntry");
+               for(const radio of radios){
+                   if(radio.value == defaultValue){
+                       radio.checked = true;
+                   }
+                   radio.addEventListener("click", function () {
+                    console.log(this.value);
+                    settings[this.name] = this.value;
+                    console.log(settings);
+                    saveGlobalSettings(settings);
+                   });
+               }
+            } 
         } catch {}
     }
     document.getElementById("server-link").href = "http://" + settings.server;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -25,6 +25,24 @@ function sendMessagePlayer(stateSend) {
     });
 }
 
+
+function populateDefaultPlaybackResolution(element){
+    for(const opt of defaultPlaybackResolutions){
+        var radio = document.createElement("input");
+        var label = document.createElement("label");
+        radio.type = "radio";
+        radio.name = "defaultPlaybackRes"
+        radio.value = opt;
+        radio.class = "defaultResRadio"
+        label.setAttribute("for", opt);
+        label.innerHTML = opt;
+        label.className = "defaultResLabel";
+        element.append(label);
+        element.append(radio);
+    }
+}
+
+
 var settings;
 loadGlobalSettings(function(returned){
     settings=returned;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -25,24 +25,6 @@ function sendMessagePlayer(stateSend) {
     });
 }
 
-
-function populateDefaultPlaybackResolution(element){
-    for(const opt of defaultPlaybackResolutions){
-        var radio = document.createElement("input");
-        var label = document.createElement("label");
-        radio.type = "radio";
-        radio.name = "defaultPlaybackRes"
-        radio.value = opt;
-        radio.class = "defaultResRadio"
-        label.setAttribute("for", opt);
-        label.innerHTML = opt;
-        label.className = "defaultResLabel";
-        element.append(label);
-        element.append(radio);
-    }
-}
-
-
 var settings;
 loadGlobalSettings(function(returned){
     settings=returned;

--- a/popup/styles.css
+++ b/popup/styles.css
@@ -75,3 +75,7 @@ input[type="url"] {
     width: 100%;
     height: 20px;
 }
+
+.defaultRadioLabel {
+    color: white;
+}

--- a/utils.js
+++ b/utils.js
@@ -8,17 +8,18 @@ function downloadURI(uri, name) {
     delete link;
 }
 
+
 // TODO - add user configurable way to select the default resolution
-var defaultResolution = "720p";
+const defaultPlaybackResolutions = ["720p", "540p", "360p", "Auto"]
 function setDefaultResolution(){
     console.log("Called set resolution");
     resolutionButtons = document.getElementsByClassName("explicit-resolution");
     console.log("Should have the buttons?");
     console.log(resolutionButtons)
     for(const resButton of resolutionButtons){
-        if(resButton.firstChild.innerText == defaultResolution){
+        if(resButton.firstChild.innerText == settings.defaultPlaybackResolution){
             resButton.click();
-            console.log("Should have set default resolution to: " + defaultResolution);
+            console.log("Should have set default resolution to: " + settings,defaultPlaybackResolution);
             break;
         }
     }
@@ -29,7 +30,8 @@ function loadGlobalSettings(callback) {
     var settings = {
         volume: 1,
         online: false,
-        server: "tct.pythonanywhere.com"
+        server: "tct.pythonanywhere.com",
+        defaultPlaybackResolution: "720p"
     }
 
     // load settings data from local storage

--- a/utils.js
+++ b/utils.js
@@ -28,7 +28,7 @@ function loadGlobalSettings(callback) {
         volume: 1,
         online: false,
         server: "tct.pythonanywhere.com",
-        defaultPlaybackResolution: "720p"
+        defaultPlaybackResolution: "Auto"
     }
 
     // load settings data from local storage

--- a/utils.js
+++ b/utils.js
@@ -8,9 +8,6 @@ function downloadURI(uri, name) {
     delete link;
 }
 
-
-// TODO - add user configurable way to select the default resolution
-const defaultPlaybackResolutions = ["720p", "540p", "360p", "Auto"]
 function setDefaultResolution(){
     console.log("Called set resolution");
     resolutionButtons = document.getElementsByClassName("explicit-resolution");


### PR DESCRIPTION
This PR adds in the global setting for default resolution per #11, and allows users to select the default resolution they would like the recordings to be played back at. Defaults to 720p, just in case people do not learn about it/find the setting, so that they still get some of the benefits of this plug-in being able to set the resolution.