### PR TITLE
Add more granular speed control + fixed play/pause button issue

### DIFF
--- a/plus.css
+++ b/plus.css
@@ -73,3 +73,57 @@
     top: -7px;
     font-family: Roboto-Regular,Roboto,sans-serif;
 }
+
+.mpp-playback-speed-container {
+    display: flex;
+    align-items: center;
+    margin: 5px 10px;
+}
+
+
+.mpp-playback-speed-container span, input {
+    font-family: Roboto-Regular,Roboto,sans-serif;
+    font-size: 14px;
+    color: black;
+}
+
+#mpp-playback-speed-display {
+    margin-left: 2.5px; /* Explicit so we override another rule */
+    margin-right: 13px;
+    margin-bottom: 1px; 
+    letter-spacing: 1px;
+    width: 36px;
+}
+
+#mpp-playback-speed-slider {
+    -webkit-appearance: none;
+    margin: 0px 0;
+}
+
+#mpp-playback-speed-slider:focus {
+    outline: none;
+}
+
+#mpp-playback-speed-slider::-moz-range-track {
+    width: 100%;
+    height: 6px;
+    cursor: pointer;
+    background: #d3d3d3;
+    border-radius: 5px;
+}
+
+#mpp-playback-speed-slider::-moz-range-progress {
+    background-color: #a0a0a0a0;
+    height: 6px;
+    border-radius: 5px;
+}
+
+#mpp-playback-speed-slider::-moz-range-thumb {
+    height: 12px;
+    width: 12px;
+    border-radius: 100%;
+    background: #ffffff;
+    cursor: pointer;
+    border: 1px none black;
+    box-shadow: -2px 3px 10px #c0c0c0;
+}

--- a/plus.css
+++ b/plus.css
@@ -130,6 +130,7 @@
     background: #ffffff;
     cursor: pointer;
     box-shadow: -2px 3px 10px #c0c0c0;
+    border: none;
 }
 
 #mpp-playback-speed-slider::-webkit-slider-thumb {
@@ -141,4 +142,5 @@
     background-color: #ffffff;
     cursor: pointer;
     box-shadow: -2px 3px 10px #c0c0c0;
+    border: none;
 }

--- a/plus.css
+++ b/plus.css
@@ -100,11 +100,7 @@
     margin: 0px 0;
 }
 
-#mpp-playback-speed-slider:focus {
-    outline: none;
-}
-
-#mpp-playback-speed-slider::-moz-range-track {
+#mpp-playback-speed-slider::-moz-range-track, #mpp-playback-speed-slider::-webkit-slider-runnable-track {
     width: 100%;
     height: 6px;
     cursor: pointer;
@@ -112,13 +108,14 @@
     border-radius: 5px;
 }
 
+/* Unfortuantely webkit doesn't have a progress feature so sucks for chrome users */
 #mpp-playback-speed-slider::-moz-range-progress {
     background-color: #a0a0a0a0;
     height: 6px;
     border-radius: 5px;
 }
 
-#mpp-playback-speed-slider::-moz-range-thumb {
+#mpp-playback-speed-slider::-moz-range-thumb, #mpp-playback-speed-slider::-webkit-slider-thumb {
     height: 12px;
     width: 12px;
     border-radius: 100%;

--- a/plus.css
+++ b/plus.css
@@ -100,7 +100,7 @@
     margin: 0px 0;
 }
 
-#mpp-playback-speed-slider::-moz-range-track, #mpp-playback-speed-slider::-webkit-slider-runnable-track {
+#mpp-playback-speed-slider::-moz-range-track {
     width: 100%;
     height: 6px;
     cursor: pointer;
@@ -108,19 +108,37 @@
     border-radius: 5px;
 }
 
-/* Unfortuantely webkit doesn't have a progress feature so sucks for chrome users */
+#mpp-playback-speed-slider::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 6px;
+    cursor: pointer;
+    background: #d3d3d3;
+    border-radius: 5px;
+}
+
+/* Unfortuantely webkit doesn't have a progress bar feature so sucks for chrome users */
 #mpp-playback-speed-slider::-moz-range-progress {
     background-color: #a0a0a0a0;
     height: 6px;
     border-radius: 5px;
 }
 
-#mpp-playback-speed-slider::-moz-range-thumb, #mpp-playback-speed-slider::-webkit-slider-thumb {
+#mpp-playback-speed-slider::-moz-range-thumb {
     height: 12px;
     width: 12px;
     border-radius: 100%;
     background: #ffffff;
     cursor: pointer;
-    border: 1px none black;
+    box-shadow: -2px 3px 10px #c0c0c0;
+}
+
+#mpp-playback-speed-slider::-webkit-slider-thumb {
+    appearance: none;
+    margin-top: -3px; /* Fix weird vertical alignment issue in chrome */
+    height: 12px;
+    width: 12px;
+    border-radius: 100%;
+    background-color: #ffffff;
+    cursor: pointer;
     box-shadow: -2px 3px 10px #c0c0c0;
 }

--- a/plus.js
+++ b/plus.js
@@ -119,7 +119,7 @@ document.arrive(".shaka-volume-bar-container", function() {
         </button>
         <div class="mpp-playback-speed-container">
             <span id="mpp-playback-speed-display">1.00</span>
-            <input id="mpp-playback-speed-slider" type="range" min="0.05" max="3" step="0.05" value="1.00"/>
+            <input id="mpp-playback-speed-slider" type="range" min="0.10" max="3" step="0.05" value="1.00"/>
         </div>`
         // Insert the new controls
         speed_changer.insertAdjacentHTML('beforeend', new_speed_controls)

--- a/plus.js
+++ b/plus.js
@@ -107,8 +107,38 @@ document.arrive(".shaka-volume-bar-container", function() {
         speed_changer.addEventListener('click', function() {
             intended_speed = vid.playbackRate;
         })
+        
+        
+        // Get rid of old controls
+        speed_changer.innerHTML = ""
+        // HTML for new controls
+        let new_speed_controls = `
+        <button class="shaka-back-to-overflow-button" aria-label="Back">
+            <i class="material-icons">arrow_back</i>
+            <span>Playback speed</span>
+        </button>
+        <div class="mpp-playback-speed-container">
+            <span id="mpp-playback-speed-display">1.00</span>
+            <input id="mpp-playback-speed-slider" type="range" min="0.05" max="3" step="0.05" value="1.00"/>
+        </div>`
+        // Insert the new controls
+        speed_changer.insertAdjacentHTML('beforeend', new_speed_controls)
 
-        // play/pause button
+        // Add event for speed changing
+        let speed_slider = document.getElementById("mpp-playback-speed-slider")
+        speed_slider.addEventListener('input', function(event) {
+            let speed = event.target.value.toString()
+            vid.playbackRate = speed
+            intended_speed = speed
+            
+            let speed_display = document.getElementById("mpp-playback-speed-display")
+            speed_display.innerHTML = parseFloat(event.target.value).toFixed(2) // to 2 dp
+        })
+
+        //remove old play/pause button (otherwise we have duplicates)
+        document.getElementsByClassName("shaka-small-play-button").item(0).remove()
+
+        // new play/pause button
         play_button = "<button class='material-icons' id='mpp-play' aria-label='Play/Pause' title='Play/Pause'>play_arrow</button>";
         document.getElementsByClassName("shaka-current-time")[0].insertAdjacentHTML("beforebegin", play_button);
         document.getElementById("mpp-play").addEventListener('click', function() {

--- a/plus.js
+++ b/plus.js
@@ -11,7 +11,7 @@ var settings = {
 // declare default values for video data
 var video_data = {
     position: 42, // default start position, skips copyright message
-    playback_speed: 1.0,
+    playback_speed: 1.0, // ldefault video speed
 }
 
 // get unique video id
@@ -72,6 +72,8 @@ document.arrive(".shaka-volume-bar-container", function() {
             }
         });
         vid.addEventListener("ratechange", function() {
+            // keep intended speed
+            intended_speed = vid.playbackRate
             video_data.playback_speed = vid.playbackRate
             // update visual elements and slider
             speed_display.innerHTML = parseFloat(vid.playbackRate).toFixed(2)
@@ -83,6 +85,9 @@ document.arrive(".shaka-volume-bar-container", function() {
         // apply settings
         vid.currentTime = video_data.position;
         vid.volume = settings.volume;
+
+        // per video speed settings 
+        intended_speed = video_data.playback_speed
         vid.playbackRate = video_data.playback_speed
 
         // action info popup
@@ -128,8 +133,8 @@ document.arrive(".shaka-volume-bar-container", function() {
             <span>Playback speed</span>
         </button>
         <div class="mpp-playback-speed-container">
-            <span id="mpp-playback-speed-display">1.00</span>
-            <input id="mpp-playback-speed-slider" type="range" min="0.10" max="3" step="0.05" value="1.00"/>
+            <span id="mpp-playback-speed-display">${parseFloat(vid.playbackRate).toFixed(2)}</span>
+            <input id="mpp-playback-speed-slider" type="range" min="0.10" max="3" step="0.05" value="${vid.playbackRate}"/>
         </div>`
         // Insert the new controls
         speed_changer.insertAdjacentHTML('beforeend', new_speed_controls)

--- a/plus.js
+++ b/plus.js
@@ -11,6 +11,7 @@ var settings = {
 // declare default values for video data
 var video_data = {
     position: 42, // default start position, skips copyright message
+    playback_speed: 1.0,
 }
 
 // get unique video id
@@ -70,12 +71,19 @@ document.arrive(".shaka-volume-bar-container", function() {
                 settings.volume = 0;
             }
         });
+        vid.addEventListener("ratechange", function() {
+            video_data.playback_speed = vid.playbackRate
+            // update visual elements and slider
+            speed_display.innerHTML = parseFloat(vid.playbackRate).toFixed(2)
+            speed_slider.value = vid.playbackRate
+        });
         controls = document.getElementsByClassName("shaka-controls-container")[0]
         vol_slider = document.getElementsByClassName("shaka-volume-bar-container")[0]
 
         // apply settings
         vid.currentTime = video_data.position;
         vid.volume = settings.volume;
+        vid.playbackRate = video_data.playback_speed
 
         // action info popup
         action_popup = "<div id='mpp-action-popup'></div>";
@@ -127,14 +135,14 @@ document.arrive(".shaka-volume-bar-container", function() {
         speed_changer.insertAdjacentHTML('beforeend', new_speed_controls)
 
         // Add event for speed changing
-        let speed_slider = document.getElementById("mpp-playback-speed-slider")
+        var speed_display = document.getElementById("mpp-playback-speed-display")
+        var speed_slider = document.getElementById("mpp-playback-speed-slider")
         speed_slider.addEventListener('input', function(event) {
             let speed = event.target.value.toString()
-            vid.playbackRate = speed
-            intended_speed = speed
-            
-            let speed_display = document.getElementById("mpp-playback-speed-display")
-            speed_display.innerHTML = parseFloat(event.target.value).toFixed(2) // to 2 dp
+            vid.playbackRate = event.target.value
+            intended_speed = event.target.value
+            // we update settings and displays inside
+            // the ratechange event callback 
         })
 
         //remove old play/pause button (otherwise we have duplicates)
@@ -240,7 +248,7 @@ document.addEventListener('keydown', function(event) {
             vid.playbackRate = 3;
         }
         intended_speed = vid.playbackRate;
-        show_popup("fast_forward", vid.playbackRate + "x");
+        show_popup("fast_forward", vid.playbackRate.toFixed(2) + "x");
     }
 
     // Decrease speed with ','
@@ -250,13 +258,14 @@ document.addEventListener('keydown', function(event) {
             vid.playbackRate = 0.25;
         }
         intended_speed = vid.playbackRate;
-        show_popup("fast_rewind", vid.playbackRate + "x");
+        show_popup("fast_rewind", vid.playbackRate.toFixed(2) + "x");
     }
 
     // Reset speed with '/'
     if(event.keyCode == 191) {
         vid.playbackRate = 1;
         intended_speed = vid.playbackRate;
+
         show_popup("speed", "1x");
     }
 

--- a/plus.js
+++ b/plus.js
@@ -16,6 +16,8 @@ var video_data = {
 // get unique video id
 var video_id = window.location.href.replace(".preview", "").replace("https://mediaplayer.auckland.ac.nz", "");
 
+//firefox compat
+var chrome = chrome || browser;
 // load video data from local storage
 chrome.storage.sync.get([video_id, "settings"], function(result) {
     console.log(result);


### PR DESCRIPTION
Changed the playback speed selection to be a sliding bar, rather than a list of options. I range for the slider is from 0.1x speed to 3x speed with 0.05x increments. This allows for more granular control of the playback speed.

There was also an issue where there were 2 play/pause buttons on the control bar, which is also fixed.

N.B. There is a slight visual difference in the playback speed slider in webkit vs firefox as the firefox css feature -mox-range-progress doesn't have an equivalent in webkit.